### PR TITLE
Adding compiled binary to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/autoload/dictionary
 /doc/tags


### PR DESCRIPTION
Ignoring the compiled binary at `autoload/dictionary`.
